### PR TITLE
fix: Remove LoaderOptionsPlugin which only exists for migration. As a…

### DIFF
--- a/src/config/webpack.build.babel.js
+++ b/src/config/webpack.build.babel.js
@@ -11,7 +11,6 @@ import CleanPlugin from 'clean-webpack-plugin';
 import ExtractTextPlugin from 'extract-text-webpack-plugin';
 import ReplaceHashWebpackPlugin from 'replace-hash-webpack-plugin';
 import ProfilesPlugin from 'packing-profile-webpack-plugin';
-import autoprefixer from 'autoprefixer';
 import pRequire from '../util/require';
 
 // js输出文件保持目录名称
@@ -121,12 +120,6 @@ const webpackConfig = () => {
   };
 
   const plugins = [
-    new webpack.LoaderOptionsPlugin({
-      options: {
-        postcss: [autoprefixer],
-      },
-    }),
-
     new CleanPlugin([assetsDist, templatesDist], {
       root: projectRootPath,
     }),

--- a/src/config/webpack.dll.babel.js
+++ b/src/config/webpack.dll.babel.js
@@ -7,7 +7,6 @@
 import path from 'path';
 import webpack from 'webpack';
 import CleanPlugin from 'clean-webpack-plugin';
-import autoprefixer from 'autoprefixer';
 import pRequire from '../util/require';
 
 const {
@@ -93,11 +92,6 @@ const webpackConfig = () => {
   };
 
   const plugins = [
-    new webpack.LoaderOptionsPlugin({
-      options: {
-        postcss: [autoprefixer],
-      },
-    }),
     new CleanPlugin([dll], {
       root: cwd,
     }),

--- a/src/config/webpack.serve.babel.js
+++ b/src/config/webpack.serve.babel.js
@@ -12,7 +12,6 @@ import DashboardPlugin from 'webpack-dashboard/plugin';
 // eslint-disable-next-line
 import OpenBrowserPlugin from 'open-browser-webpack-plugin';
 import ProfilesPlugin from 'packing-profile-webpack-plugin';
-import autoprefixer from 'autoprefixer';
 import pRequire from '../util/require';
 
 const packing = pRequire('config/packing');
@@ -133,11 +132,6 @@ const webpackConfig = (program) => {
   };
 
   const plugins = [
-    new webpack.LoaderOptionsPlugin({
-      options: {
-        postcss: [autoprefixer],
-      },
-    }),
     new ProfilesPlugin(),
   ];
 


### PR DESCRIPTION
Remove LoaderOptionsPlugin which only exists for migration. As a result, this fixs the problem that the file "postcss.config.js" dose not work.